### PR TITLE
ToImplement failure test case (fixed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Matcher::register('toEqualOneOf', 'Kahlan\Extra\Matcher\ToEqualOneOf');
 Matcher::register('toImplement', 'Kahlan\Matcher\ToBeAnInstanceOf'); // Alias
 ```
 
+Or in case you want to register all matchers, you can write:
+
+```php
+require_once 'vendor/kahlan/extra-matcher/kahlan-config.php';
+```
+
 ## Documentation
 
 **toBeOneOf($expected)** // strict comparison
@@ -43,5 +49,18 @@ it("passes if $actual is present in $expected", function() {
 ```php
 it("passes if $actual is present in $expected", function() {
     expect("3")->toEqualOneOf([1, 2, 3]);
+});
+```
+
+**toImplement($expected)** // object implements expected interface 
+
+```php
+it("passes if $actual implements $expected", function() {
+    
+    interface foo { }
+    class bar implements foo {}
+    
+    $actual = new bar(); 
+    expect($actual)->toImplement('foo');
 });
 ```

--- a/kahlan-config.php
+++ b/kahlan-config.php
@@ -3,3 +3,4 @@ use Kahlan\Matcher;
 
 Matcher::register('toBeOneOf', 'Kahlan\Extra\Matcher\ToBeOneOf');
 Matcher::register('toEqualOneOf', 'Kahlan\Extra\Matcher\ToEqualOneOf');
+Matcher::register('toImplement', 'Kahlan\Matcher\ToBeAnInstanceOf'); // Alias

--- a/kahlan-config.travis.php
+++ b/kahlan-config.travis.php
@@ -6,3 +6,4 @@ $commandLine->option('coverage', 'default', 3);
 
 Matcher::register('toBeOneOf', 'Kahlan\Extra\Matcher\ToBeOneOf');
 Matcher::register('toEqualOneOf', 'Kahlan\Extra\Matcher\ToEqualOneOf');
+Matcher::register('toImplement', 'Kahlan\Matcher\ToBeAnInstanceOf'); // Alias

--- a/spec/Bar.php
+++ b/spec/Bar.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Kahlan\Extra\Matcher\Spec;
+
+class Bar implements Foo
+{
+}

--- a/spec/Foo.php
+++ b/spec/Foo.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Kahlan\Extra\Matcher\Spec;
+
+interface Foo
+{
+}

--- a/spec/ToImplement.spec.php
+++ b/spec/ToImplement.spec.php
@@ -1,0 +1,31 @@
+<?php
+namespace Kahlan\Extra\Matcher\Spec;
+
+use Kahlan\Matcher\ToBeAnInstanceOf;
+use stdClass;
+
+describe('ToImplement', function () {
+
+    describe('::match()', function () {
+
+        it('passes if $actual is implements of $expected', function () {
+            
+            interface foo { }
+            class bar implements foo {}
+                
+            $actual = new bar();
+            $expeted = 'foo';
+            
+            expect($actual)->toImplement('foo');
+
+        });
+        
+        it('fails passes if $actual is not implement of $expected', function () {
+
+            expect(new stdClass())->not->toImplement('fux');
+
+        });
+
+    });
+
+});

--- a/spec/ToImplement.spec.php
+++ b/spec/ToImplement.spec.php
@@ -8,7 +8,7 @@ describe('ToImplement', function () {
     describe('::match()', function () {
         it('passes if $actual is implements of $expected', function () {
             $actual = new Bar();
-            $expeted = 'Foo';
+            $expeted = 'Kahlan\Extra\Matcher\Spec\Foo';
 
             expect($actual)->toImplement($expeted);
         });

--- a/spec/ToImplement.spec.php
+++ b/spec/ToImplement.spec.php
@@ -1,31 +1,20 @@
 <?php
+
 namespace Kahlan\Extra\Matcher\Spec;
 
-use Kahlan\Matcher\ToBeAnInstanceOf;
 use stdClass;
 
 describe('ToImplement', function () {
-
     describe('::match()', function () {
-
         it('passes if $actual is implements of $expected', function () {
-            
-            interface foo { }
-            class bar implements foo {}
-                
-            $actual = new bar();
-            $expeted = 'foo';
-            
-            expect($actual)->toImplement('foo');
+            $actual = new Bar();
+            $expeted = 'Foo';
 
+            expect($actual)->toImplement($expeted);
         });
-        
+
         it('fails passes if $actual is not implement of $expected', function () {
-
-            expect(new stdClass())->not->toImplement('fux');
-
+            expect(new stdClass())->not->toImplement('Fux');
         });
-
     });
-
 });

--- a/spec/ToImplement.spec.php
+++ b/spec/ToImplement.spec.php
@@ -5,16 +5,23 @@ namespace Kahlan\Extra\Matcher\Spec;
 use stdClass;
 
 describe('ToImplement', function () {
+
     describe('::match()', function () {
+
         it('passes if $actual is implements of $expected', function () {
+
             $actual = new Bar();
             $expeted = 'Kahlan\Extra\Matcher\Spec\Foo';
 
             expect($actual)->toImplement($expeted);
+
         });
 
         it('fails passes if $actual is not implement of $expected', function () {
+
             expect(new stdClass())->not->toImplement('Fux');
+
         });
+
     });
 });


### PR DESCRIPTION
@jails I think toImplement need to be separate class based on this failure test case:

```
.......F.                                                           9 / 9 (100%)

ToImplement
  ::match()
    ✖ it passes if $actual is implements of $expected
      expect->toImplement() failed in `./spec/ToImplement.spec.php` line 13

      It expect actual to be an instance of expected.

      actual:
        (object) an instance of `Kahlan\Extra\Matcher\Spec\Bar`
      expected:
        (string) "Foo"



Expectations   : 10 Executed
Specifications : 0 Pending, 0 Excluded, 0 Skipped
```
